### PR TITLE
Spotify Integration

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -214,10 +214,15 @@
 ### `timezone`  
 *Description:* `converts between timezones, using DuckDuckGo searches`  
 *Usage:* `timezone <time> to <time>`  
-*Credits:* `<@136641861073764352>
+*Credits:* `<@136641861073764352>`
 
 ### `translate`  
 *Description:* `Translates text from/to any language`  
 *Usage:* `translate <lang> <text>`  
-*Credits:* `Carbowix
+*Credits:* `Carbowix`
+
+### `spotify`  
+*Description:* `Shows information about spotify tracks`  
+*Usage:* `spotify <trackUrl>`  
+*Credits:* `Doxylamin <@140541588915879936>`
 

--- a/src/commands/Utility/spotify.js
+++ b/src/commands/Utility/spotify.js
@@ -13,7 +13,7 @@ exports.run = function (bot, msg, args) {
     let input = args.join(' ')
         .replace('https://open.spotify.com/track/','')
         .replace('spotify:track:','');
-    let url = `https://api.spotify.com/v1/track/${input}`;
+    let url = `https://api.spotify.com/v1/tracks/${input}`;
     msg.edit(':arrows_counterclockwise:  Loading track info for ' + input);
 
     got(url).then(res => {

--- a/src/commands/Utility/spotify.js
+++ b/src/commands/Utility/spotify.js
@@ -13,13 +13,19 @@ exports.run = function (bot, msg, args) {
     let input = args.join(' ')
         .replace('https://open.spotify.com/track/','')
         .replace('spotify:track:','');
-    let url = `https://api.spotify.com/v1/tracks/${input}`;
+    let url = `https://api.spotify.com/v1/track/${input}`;
     msg.edit(':arrows_counterclockwise:  Loading track info for ' + input);
 
-    got(url)
-    .then(res => {
+    got(url).then(res => {
 
-        let data = JSON.parse(res.body);
+        let data;
+
+        try {
+            data = JSON.parse(res.body);
+        } catch (e) {
+            msg.error('SpotifyAPI returned weird data. See console.');
+            bot.logger.severe(e);
+        }
 
         if (data['type'] === 'track') {
             
@@ -75,8 +81,7 @@ exports.run = function (bot, msg, args) {
             msg.error(`No info found for ${input}`);
         }
 
-    })
-    .catch(err => {
+    }).catch(err => {
         msg.error('SpotifyAPI returned an error. See console.');
         bot.logger.severe(err);
     });

--- a/src/commands/Utility/spotify.js
+++ b/src/commands/Utility/spotify.js
@@ -1,0 +1,90 @@
+const got = require('got');
+
+exports.run = function (bot, msg, args) {
+    if (args.length < 1) {
+        throw 'You must specify a track url (spotify:track:XYZ)';
+    }
+
+    // possible inputs:
+    // https://open.spotify.com/track/4SUBEjh0WcaPXNeBpuRC7a
+    // spotify:track:4SUBEjh0WcaPXNeBpuRC7a
+    // 4SUBEjh0WcaPXNeBpuRC7a
+
+    let input = args.join(' ')
+        .replace('https://open.spotify.com/track/','')
+        .replace('spotify:track:','');
+    let url = `https://api.spotify.com/v1/tracks/${input}`;
+    msg.edit(':arrows_counterclockwise:  Loading track info for ' + input);
+
+    got(url)
+    .then(res => {
+
+        let data = JSON.parse(res.body);
+
+        if (data['type'] === 'track') {
+            
+            let artists = [];
+            data['artists'].forEach(function(artist) {
+                artists.push(artist.name);
+            }, this);
+
+            let duration_m = Math.floor(data.duration_ms / 60000);
+            let duration_s = ((data.duration_ms % 60000) / 1000).toFixed(0);
+
+            let embed = bot.utils.embed(
+                'Listen now!',
+                `${msg.author.username} is currently listening to`,
+                [
+                    {
+                        name: 'Artist(s)',
+                        value: `${artists.join(', ')}`,
+                    },
+                    {
+                        name: 'Title',
+                        value: `${data.name}`,
+                    },
+                    {
+                        name: 'Explict',
+                        value: `${(data.explict)?'yes':'no'}`,
+                    },
+                    {
+                        name: 'Popularity',
+                        value: `${data.popularity} %`,
+                    },
+                    {
+                        name: 'Duration',
+                        value:  (duration_s == 60 ? (duration_m+1) + ':00' : duration_m + ':' + (duration_s < 10 ? '0' : '') + duration_s) + 'min',
+                    },
+                    {
+                        name: 'Markets',
+                        value:  `Song is available on ${data.available_markets.length} markets`,
+                    },
+                ],
+                {
+                    inline: true,
+                    footer: 'Spotify Track Info',
+                    color: [30, 215, 96]
+                });
+            
+            embed.setThumbnail(`${data['album']['images'][2]['url']}`);
+            embed.setURL(`${data['external_urls']['spotify']}`);
+            msg.delete();
+            msg.channel.sendEmbed(embed);
+
+        } else {
+            msg.error(`No info found for ${input}`);
+        }
+
+    })
+    .catch(err => {
+        msg.error('SpotifyAPI returned an error. See console.');
+        bot.logger.severe(err);
+    });
+};
+
+exports.info = {
+    name: 'spotify',
+    usage: 'spotify <trackurl>',
+    description: 'shows detailed information about a spotify track',
+    credits: '<@140541588915879936>' // Doxylamin#4539
+};


### PR DESCRIPTION
Added spotify integration using the [Spotify WebAPI (v1)](https://developer.spotify.com/web-api/get-track/).

Usage: `spotify <trackurl>`

Track URL has to be in one of the following formats:

- https://open.spotify.com/track/2OccinWNEPIEmZPkqnLPSR
- spotify:track:2OccinWNEPIEmZPkqnLPSR
- 2OccinWNEPIEmZPkqnLPSR