### PR TITLE
Self destructing messages with styling.

### DIFF
--- a/src/commands/Fun/destruct.js
+++ b/src/commands/Fun/destruct.js
@@ -1,0 +1,52 @@
+exports.run = function(bot,msg,args) {
+
+    let parsedArgs = bot.utils.parseArgs(args, ['d:','s:']);
+
+    if(parsedArgs.leftover.length < 1) {
+        throw 'Please provide a secret message';
+    }
+
+    let text = parsedArgs.leftover;
+    let message = text.join(' ');
+    let delay = isNaN(parsedArgs.options.d) ? 5000 : parsedArgs.options.d;
+    let style = (typeof parsedArgs.options.s === 'string') ? parsedArgs.options.s : 'plain';
+
+    msg.delete();
+
+    switch(style) {
+    case 'embed':
+        message = bot.utils.embed(
+            `This message self-destructs in ${delay/1000} seconds.`,
+            `${message}`,
+            [],
+            {
+                inline: true,
+                footer: 'Secret Message',
+                color: [255, 0, 0]
+            }
+        );
+        msg.channel.sendEmbed(message).then(m => { m.delete(delay); });
+        break;
+    case 'inline':
+        message = `*This message self-destructs in ${delay/1000} seconds.*\n${message}`;
+        msg.channel.send(message).then(m => { m.delete(delay); });
+        break;
+    case 'code':
+        message = `*This message self-destructs in ${delay/1000} seconds.*\n\`\`\`${message}\`\`\``;
+        msg.channel.send(message).then(m => { m.delete(delay); });
+        break;
+    default:
+        message = `${message}`;
+        msg.channel.send(message).then(m => { m.delete(delay); });
+        break;
+    }
+
+};
+
+
+exports.info = {
+    name: 'destruct',
+    usage: 'destruct [-d delay in ms]  [-s <embed|inline|code>] <message>',
+    description: 'creates a self-destructing message',
+    credits: '<@140541588915879936>' // Doxylamin#4539
+};

--- a/src/commands/Fun/destruct.js
+++ b/src/commands/Fun/destruct.js
@@ -1,6 +1,6 @@
 exports.run = function(bot,msg,args) {
 
-    let parsedArgs = bot.utils.parseArgs(args, ['d:','s:']);
+    const parsedArgs = bot.utils.parseArgs(args, ['d:','s:']);
 
     if(parsedArgs.leftover.length < 1) {
         throw 'Please provide a secret message';
@@ -9,7 +9,7 @@ exports.run = function(bot,msg,args) {
     let message = parsedArgs.leftover.join(' ');
     let delay = isNaN(parsedArgs.options.d) ? 5000 : parseInt(parsedArgs.options.d);
     delay = (delay < 100) ? 100 : delay;
-    let style = (typeof parsedArgs.options.s === 'string') ? parsedArgs.options.s : 'plain';
+    const style = (typeof parsedArgs.options.s === 'string') ? parsedArgs.options.s : 'plain';
 
     msg.delete();
 

--- a/src/commands/Fun/destruct.js
+++ b/src/commands/Fun/destruct.js
@@ -22,8 +22,7 @@ exports.run = function(bot,msg,args) {
                 [],
                 {
                     inline: true,
-                    footer: 'Secret Message',
-                    color: [255, 0, 0]
+                    footer: 'Secret Message'
                 }
             )
         };

--- a/src/commands/Fun/destruct.js
+++ b/src/commands/Fun/destruct.js
@@ -48,5 +48,17 @@ exports.info = {
     name: 'destruct',
     usage: 'destruct [-d delay in ms]  [-s <embed|inline|code>] <message>',
     description: 'creates a self-destructing message',
+    options:[
+        {
+            name: '-d',
+            usage: '-d <delay in ms>',
+            description: 'Sets the time (in ms) for the message to be deleted. (Default: 5 seconds)'
+        },
+        {
+            name: '-s',
+            usage: '-s <embed|inline|code|plain>',
+            description: 'Sets the message style (default: plain)'
+        }
+    ],
     credits: '<@140541588915879936>' // Doxylamin#4539
 };

--- a/src/commands/Fun/destruct.js
+++ b/src/commands/Fun/destruct.js
@@ -6,40 +6,37 @@ exports.run = function(bot,msg,args) {
         throw 'Please provide a secret message';
     }
 
-    let text = parsedArgs.leftover;
-    let message = text.join(' ');
-    let delay = isNaN(parsedArgs.options.d) ? 5000 : parsedArgs.options.d;
+    let message = parsedArgs.leftover.join(' ');
+    let delay = isNaN(parsedArgs.options.d) ? 5000 : parseInt(parsedArgs.options.d);
+    delay = (delay < 100) ? 100 : delay;
     let style = (typeof parsedArgs.options.s === 'string') ? parsedArgs.options.s : 'plain';
 
     msg.delete();
 
     switch(style) {
     case 'embed':
-        message = bot.utils.embed(
-            `This message self-destructs in ${delay/1000} seconds.`,
-            `${message}`,
-            [],
-            {
-                inline: true,
-                footer: 'Secret Message',
-                color: [255, 0, 0]
-            }
-        );
-        msg.channel.sendEmbed(message).then(m => { m.delete(delay); });
+        message = {
+            embed: bot.utils.embed(
+                `This message self-destructs in ${delay/1000} seconds.`,
+                message,
+                [],
+                {
+                    inline: true,
+                    footer: 'Secret Message',
+                    color: [255, 0, 0]
+                }
+            )
+        };
         break;
     case 'inline':
         message = `*This message self-destructs in ${delay/1000} seconds.*\n${message}`;
-        msg.channel.send(message).then(m => { m.delete(delay); });
         break;
     case 'code':
         message = `*This message self-destructs in ${delay/1000} seconds.*\n\`\`\`${message}\`\`\``;
-        msg.channel.send(message).then(m => { m.delete(delay); });
-        break;
-    default:
-        message = `${message}`;
-        msg.channel.send(message).then(m => { m.delete(delay); });
         break;
     }
+
+    msg.channel.send(message).then(m => m.delete(delay));
 
 };
 

--- a/src/commands/Fun/destruct.js
+++ b/src/commands/Fun/destruct.js
@@ -46,7 +46,7 @@ exports.run = function(bot,msg,args) {
 
 exports.info = {
     name: 'destruct',
-    usage: 'destruct [-d delay in ms]  [-s <embed|inline|code>] <message>',
+    usage: 'destruct [-d delay in ms]  [-s <embed|inline|code|plain>] <message>',
     description: 'creates a self-destructing message',
     options:[
         {


### PR DESCRIPTION
Adds a command for self-destructing messages.

Command Syntax: `destruct [-d <delay in ms>]  [-s <embed|inline|code|plain>] <message>`

Usage Example & Previews:

`destruct -d 5000 -s embed <message>`
![auswahl_225](https://cloud.githubusercontent.com/assets/14816200/26283414/5748b010-3e28-11e7-8501-826242e3d5b0.png)

`destruct -d 5000 -s inline <message>`
![auswahl_226](https://cloud.githubusercontent.com/assets/14816200/26283416/574abb4e-3e28-11e7-95ad-574b26db5963.png)

`destruct -d 5000 -s code <message>`
![auswahl_227](https://cloud.githubusercontent.com/assets/14816200/26283415/574958f8-3e28-11e7-8329-e4ca711780d7.png)

`destruct -d 5000 -s plain <message>`
![auswahl_228](https://cloud.githubusercontent.com/assets/14816200/26283413/57488e82-3e28-11e7-9bce-b86bd787645f.png)