### PR TITLE
Space between each letter for mobile (fanceh command)

### DIFF
--- a/src/commands/Fun/fanceh.js
+++ b/src/commands/Fun/fanceh.js
@@ -17,7 +17,7 @@ const mapping = {
 };
 
 'abcdefghijklmnopqrstuvwxyz'.split('').forEach(c => {
-    mapping[c] = mapping[c.toUpperCase()] = `:regional_indicator_${c}:`;
+    mapping[c] = mapping[c.toUpperCase()] = ` :regional_indicator_${c}:`;
 });
 
 exports.run = (bot, msg, args) => {


### PR DESCRIPTION
Simple PR, but fixes an issue (at least on iOS) that causes a lot of the output of the `fanceh` command to not display properly. For example, `test` displays `:flag_es:` in between due to the mobile behavior `:regional_indicator_e::regional_indicator_s:` 

This just adds a space, fixing all those issues. :) (`:regional_indicator_e: :regional_indicator_s:` )