### PR TITLE
Add in UUID and Discriminator to Mutual Command

### DIFF
--- a/src/commands/Info/mutual.js
+++ b/src/commands/Info/mutual.js
@@ -8,13 +8,13 @@ exports.run = async (bot, msg, args) => {
     }
 
     const query = args.join(' ').toLowerCase();
-	// Try to parse by Server Name fist or Server ID
+    // Try to parse by Server Name fist or Server ID
     const guild = bot.guilds.find(guild => guild.name.toLowerCase() === query || guild.id === query);
-	
-	if (!guild) {
-		throw 'That guild could not be found!';
-	}
-	
+
+    if (!guild) {
+        throw 'That guild could not be found!';
+    }
+
     const mutual = bot.users.filter(user => inGuild(msg.guild, user) && inGuild(guild, user));
 
     await msg.edit(':arrows_counterclockwise: Searching...');

--- a/src/commands/Info/mutual.js
+++ b/src/commands/Info/mutual.js
@@ -19,11 +19,11 @@ exports.run = async (bot, msg, args) => {
 
     await msg.edit(':arrows_counterclockwise: Searching...');
 
-    const { url } = await bot.utils.gistUpload(mutual.map(user => `- ${user.username}#${user.discriminator}`).join('\n'), 'txt');
+    const { url } = await bot.utils.gistUpload(mutual.map(user => `- ${user.tag}`).join('\n'), 'txt');
 
     msg.delete();
     (await msg.channel.send({
-        embed: bot.utils.embed(`Mutual members of ${guild.name}`, limitTo(mutual.array().map(user => (user.username + "#" + user.discriminator)), 25, ', '), [
+        embed: bot.utils.embed(`Mutual members of ${guild.name}`, limitTo(mutual.array().map(user => user.tag), 25, ', '), [
             {
                 name: 'Full List',
                 value: url

--- a/src/commands/Info/mutual.js
+++ b/src/commands/Info/mutual.js
@@ -8,21 +8,22 @@ exports.run = async (bot, msg, args) => {
     }
 
     const query = args.join(' ').toLowerCase();
-    const guild = bot.guilds.find(guild => guild.name.toLowerCase() === query);
-
-    if (!guild) {
-        throw 'That guild could not be found!';
-    }
-
+	// Try to parse by Server Name fist or Server ID
+    const guild = bot.guilds.find(guild => guild.name.toLowerCase() === query || guild.id === query);
+	
+	if (!guild) {
+		throw 'That guild could not be found!';
+	}
+	
     const mutual = bot.users.filter(user => inGuild(msg.guild, user) && inGuild(guild, user));
 
     await msg.edit(':arrows_counterclockwise: Searching...');
 
-    const { url } = await bot.utils.gistUpload(mutual.map(user => `- ${user.username}`).join('\n'), 'txt');
+    const { url } = await bot.utils.gistUpload(mutual.map(user => `- ${user.username}#${user.discriminator}`).join('\n'), 'txt');
 
     msg.delete();
     (await msg.channel.send({
-        embed: bot.utils.embed(`Mutual members of ${guild.name}`, limitTo(mutual.array().map(user => user.username), 25, ', '), [
+        embed: bot.utils.embed(`Mutual members of ${guild.name}`, limitTo(mutual.array().map(user => (user.username + "#" + user.discriminator)), 25, ', '), [
             {
                 name: 'Full List',
                 value: url


### PR DESCRIPTION
Maintainers may make changes, I can remake the PR to separate the Discriminator change and the UUID change.

[Line 12](https://github.com/RayzrDev/SharpBot/pull/124/files#diff-dd92b133f1023d4cdc5eeb3d2c710335R12) is the primary concern, I personally like a OR for one check for this but it was suggested to use a function. 

Example (See also #code-help channel for a live on from November 11th 2017 about 4 AM EST)
![discord](https://user-images.githubusercontent.com/6324853/32771594-29ce8002-c8f1-11e7-9514-31b7bcdcf94f.png)

