### PR TITLE
stats now shows the activity type

### DIFF
--- a/src/commands/Info/stats.js
+++ b/src/commands/Info/stats.js
@@ -9,7 +9,7 @@ const formatTime = (time) => {
     return `${hours.toFixed(0)}h ${minutes.toFixed(0)}m ${seconds.toFixed(0)}s`;
 };
 
-const ActivityTypes = [
+const activityTypes = [
     'playing',
     'streaming',
     'listening to',
@@ -55,7 +55,7 @@ exports.run = async (bot, msg) => {
             },
             {
                 name: ':video_game: Game',
-                value: (game.name)?`*${ActivityTypes[game.type]}* ${game.name} ${game.streaming ? `[(Streaming)](${game.url})` : ''}`:'none'
+                value: (game.name) ? `*${activityTypes[game.type]}* ${game.name} ${game.streaming ? `[(Streaming)](${game.url})` : ''}` : 'none'
             }
         ], { inline: true })
     })).delete(30000);

--- a/src/commands/Info/stats.js
+++ b/src/commands/Info/stats.js
@@ -9,6 +9,13 @@ const formatTime = (time) => {
     return `${hours.toFixed(0)}h ${minutes.toFixed(0)}m ${seconds.toFixed(0)}s`;
 };
 
+const ActivityTypes = [
+    'playing',
+    'streaming',
+    'listening to',
+    'watching',
+];
+
 exports.run = async (bot, msg) => {
     const game = bot.user.presence.game || {};
 
@@ -48,7 +55,7 @@ exports.run = async (bot, msg) => {
             },
             {
                 name: ':video_game: Game',
-                value: `${game.name || 'None'} ${game.streaming ? `[(Streaming)](${game.url})` : ''}`
+                value: (game.name)?`*${ActivityTypes[game.type]}* ${game.name} ${game.streaming ? `[(Streaming)](${game.url})` : ''}`:'none'
             }
         ], { inline: true })
     })).delete(30000);


### PR DESCRIPTION
Since Discord is implementing new activity types (WATCHING, LISTENING) as referred here: [hydrabolt/discord.js/src/util/Constants.js#L356](https://github.com/hydrabolt/discord.js/blob/bc30fdd8671d3a82ca90ede3c7df571ca3f0ecf2/src/util/Constants.js#L356)

To test: `eval bot.user.setPresence({game:{name:"something",type:3}});`

ActivityTypes are:

0. NONE
1. PLAYING
2. STREAMING
3. LISTENING
4. WATCHING